### PR TITLE
Translations in their own files, optimally formatted

### DIFF
--- a/stringify.js
+++ b/stringify.js
@@ -1,0 +1,10 @@
+export default function stringify(obj) {
+  return JSON.stringify(obj, null, 2)
+    .replace(/"([a-zA-Z]+)":/g, "$1:")
+    .replace(/"/g, `\``)
+    .replace(/`([^`]+)`:/g, '"$1":')
+    .replace(
+      /\{\s+text: `([^`]+)`,\s+rtl: (true|false),\s+languageId: `([^`]+)`\s+\},?/gmu,
+      `{ text: \`$1\`, rtl: $2, languageId: \`$3\` },`
+    )
+}

--- a/translationsInjecter.js
+++ b/translationsInjecter.js
@@ -167,7 +167,9 @@ export default function inject(contents, origTranslations, translationsFile) {
 
   return {
     output: contents,
-    translations: `export default translations = ${stringify(t)}`,
+    translations: `// prettier-ignore\nexport default translations = ${stringify(
+      t
+    )}`,
     warnings,
     hasContent,
   }

--- a/translationsInjecter.js
+++ b/translationsInjecter.js
@@ -1,3 +1,5 @@
+import stringify from "./stringify.js"
+
 const languages = {
   en: { rtl: false },
   sv: { rtl: false },
@@ -15,7 +17,7 @@ const languages = {
   th: { rtl: false },
 }
 
-export default function inject(contents, origTranslations) {
+export default function inject(contents, origTranslations, translationsFile) {
   const warnings = []
   const languageIds = Object.keys(origTranslations)
 
@@ -139,28 +141,35 @@ export default function inject(contents, origTranslations) {
   // kill any existing translate functions. NOTE: This removes everything from translations to end-of-page
   contents = contents.replace(/\nconst translations = {(.|\n)*$/, ``)
 
+  // kill any existing translate imports.
+  contents = contents.replace(
+    /import translations from "\.\/translations.js"\n/,
+    ``
+  )
+
   const injectAvailable = keys.has(`availableLanguages`)
   keys.delete(`availableLanguages`)
 
-  if (keys.size > 0 || injectAvailable) {
-    const translations = {}
+  const hasContent = keys.size > 0 || injectAvailable
+  const t = {}
 
+  if (hasContent) {
     for (const k of [...keys].sort()) {
-      translations[k] = translationsFor(k)
+      t[k] = translationsFor(k)
     }
 
     if (injectAvailable) {
-      translations.availableLanguages = Object.keys(languages)
+      t.availableLanguages = Object.keys(languages)
     }
 
-    contents = `${contents}\n\nconst translations = ${JSON.stringify(
-      translations
-    )}`
+    contents = `import translations from "./${translationsFile}"\n${contents}`
   }
 
   return {
     output: contents,
+    translations: `export default translations = ${stringify(t)}`,
     warnings,
+    hasContent,
   }
 }
 

--- a/translationsInjecter.js
+++ b/translationsInjecter.js
@@ -143,7 +143,7 @@ export default function inject(contents, origTranslations, translationsFile) {
 
   // kill any existing translate imports.
   contents = contents.replace(
-    /import translations from "\.\/translations.js"\n/,
+    /import translations from "\.\/.*\.translations.js"\n/,
     ``
   )
 

--- a/translationsInjecterTest.js
+++ b/translationsInjecterTest.js
@@ -30,12 +30,14 @@ try {
   /* === TEST === */
   console.log("==== It should inject import tag and provide translations")
   let input = `translations.simple.en`
-  let expected = `export default translations = ${stringify({
-    simple: {
-      en: { text: `Simple`, rtl: false, languageId: `en` },
-      sv: { text: `Enkelt`, rtl: false, languageId: `sv` },
-    },
-  })}`
+  let expected = `// prettier-ignore\nexport default translations = ${stringify(
+    {
+      simple: {
+        en: { text: `Simple`, rtl: false, languageId: `en` },
+        sv: { text: `Enkelt`, rtl: false, languageId: `sv` },
+      },
+    }
+  )}`
 
   assert.equal(inject(input, translations).translations, expected)
   assert.equal(
@@ -46,7 +48,7 @@ try {
   /* === TEST === */
   console.log("==== It should create new objects with params")
   input = `translations.animal.en.duck`
-  expected = `export default translations = ${stringify({
+  expected = `// prettier-ignore\nexport default translations = ${stringify({
     animal: {
       en: {
         duck: { text: `A duck`, rtl: false, languageId: `en` },
@@ -64,7 +66,7 @@ try {
   /* === TEST === */
   console.log("==== It should use other language if specified with use(...)")
   input = `translations.onlyEn.sv`
-  expected = `export default translations = ${stringify({
+  expected = `// prettier-ignore\nexport default translations = ${stringify({
     onlyEn: {
       en: { text: `This is English`, rtl: false, languageId: `en` },
       sv: { text: `This is English`, rtl: false, languageId: `en` },

--- a/translationsInjecterTest.js
+++ b/translationsInjecterTest.js
@@ -1,7 +1,9 @@
-// simple unit test for translations injecter, just run it with node v13 or later// Using `supervisor` is recommmended
+// simple unit test for translations injecter, just run it with node v13 or later
+// Using `supervisor -n exit translationsInjecterTest.js` is recommmended
 
 import assert from "assert"
 import inject from "./translationsInjecter.js"
+import stringify from "./stringify.js"
 
 try {
   const translations = {
@@ -26,50 +28,50 @@ try {
   }
 
   /* === TEST === */
-  console.log("==== It should only inject needed keys")
+  console.log("==== It should inject import tag and provide translations")
   let input = `translations.simple.en`
-  let expected = `translations.simple.en\n\nconst translations = ${JSON.stringify(
-    {
-      simple: {
-        en: { text: `Simple`, rtl: false, languageId: `en` },
-        sv: { text: `Enkelt`, rtl: false, languageId: `sv` },
-      },
-    }
-  )}`
+  let expected = `export default translations = ${stringify({
+    simple: {
+      en: { text: `Simple`, rtl: false, languageId: `en` },
+      sv: { text: `Enkelt`, rtl: false, languageId: `sv` },
+    },
+  })}`
 
-  assert.equal(inject(input, translations).output, expected)
+  assert.equal(inject(input, translations).translations, expected)
+  assert.equal(
+    inject(input, translations, `test.translations.js`).output,
+    `import translations from "./test.translations.js"\ntranslations.simple.en`
+  )
 
   /* === TEST === */
   console.log("==== It should create new objects with params")
   input = `translations.animal.en.duck`
-  expected = `translations.animal.en.duck\n\nconst translations = ${JSON.stringify(
-    {
-      animal: {
-        en: {
-          duck: { text: `A duck`, rtl: false, languageId: `en` },
-          donkey: { text: `A donkey`, rtl: false, languageId: `en` },
-        },
-        sv: {
-          duck: { text: `En anka`, rtl: false, languageId: `sv` },
-          donkey: { text: `En åsna`, rtl: false, languageId: `sv` },
-        },
+  expected = `export default translations = ${stringify({
+    animal: {
+      en: {
+        duck: { text: `A duck`, rtl: false, languageId: `en` },
+        donkey: { text: `A donkey`, rtl: false, languageId: `en` },
       },
-    }
-  )}`
+      sv: {
+        duck: { text: `En anka`, rtl: false, languageId: `sv` },
+        donkey: { text: `En åsna`, rtl: false, languageId: `sv` },
+      },
+    },
+  })}`
 
-  assert.equal(inject(input, translations).output, expected)
+  assert.equal(inject(input, translations).translations, expected)
 
   /* === TEST === */
   console.log("==== It should use other language if specified with use(...)")
   input = `translations.onlyEn.sv`
-  expected = `translations.onlyEn.sv\n\nconst translations = ${JSON.stringify({
+  expected = `export default translations = ${stringify({
     onlyEn: {
       en: { text: `This is English`, rtl: false, languageId: `en` },
       sv: { text: `This is English`, rtl: false, languageId: `en` },
     },
   })}`
 
-  assert.equal(inject(input, translations).output, expected)
+  assert.equal(inject(input, translations).translations, expected)
 
   /* === TEST === */
   console.log("==== It should warn about missing translations")


### PR DESCRIPTION
This changes so that translations are put in their own file based on the file that uses it. `muppet.js` that uses a translation will inject `import translations from "./muppet.translations.js"` 

The file created is now optimized for gzipping and reading in a uniform way. I didn't like how prettier was sometimes splitting a translation object onto several lines.