### PR TITLE
Strict keys, better warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ async function run() {
     const contents = readFileSync(file, `utf-8`)
     const result = inject(contents, translations, translationsFileRelative)
     result.warnings.forEach((w) => {
-      allWarnings.push(`${w}\t\t${file}`)
+      allWarnings.push(`${file}\t\t${w}`)
     })
 
     writeFileSync(file, result.output, `utf-8`)

--- a/translationsInjecter.js
+++ b/translationsInjecter.js
@@ -90,7 +90,7 @@ export default function inject(contents, origTranslations, translationsFile) {
     }
   }
 
-  const callsRegex = /translations\.([^.[]+)(\.([^.(]+)|\[[^\]]+\])/gm
+  const callsRegex = /translations\.([a-z][a-zA-Z]*)(\.([^.(]+)|\[[^\]]+\])/gm
 
   const keys = new Set()
 
@@ -128,13 +128,21 @@ export default function inject(contents, origTranslations, translationsFile) {
   function translationsFor(key) {
     const ret = {}
     if (!translations.en.hasOwnProperty(key)) {
-      throw new Error(
+      warnings.push(
         `The key '${key}' was requested, but there is no such row in the document`
       )
+      languageIds.forEach((languageId) => {
+        ret[languageId] = {
+          languageId: `en`,
+          rtl: false,
+          text: `!!! no translation !!!]`,
+        }
+      })
+    } else {
+      languageIds.forEach((languageId) => {
+        ret[languageId] = translation(key, languageId)
+      })
     }
-    languageIds.forEach((languageId) => {
-      ret[languageId] = translation(key, languageId)
-    })
     return ret
   }
 


### PR DESCRIPTION
This changes so that the keys will only be recognized if they start with a small letter and then continues with small/big letters. Before it could match pretty much anything, even newlines, which lead to some pretty mysterious errors.

Also, changed so that tool doesn't quit on first missed translation. Instead, all missing rows are now shown as warnings to console.