### PR TITLE
Enable and enforce path

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { writeFileSync, readFileSync, unlinkSync } from "fs"
+import { writeFileSync, readFileSync, unlinkSync, realpathSync } from "fs"
 import { exec } from "child_process"
 
 import { getTranslations, getJavascriptFiles } from "./translationsImporter.js"
@@ -11,11 +11,27 @@ if (!process.env.TRANSLATIONS_URL) {
   process.exit(1)
 }
 
+const [_bin, _file, targetRelative] = process.argv
+
+if (!targetRelative) {
+  console.log(process.argv)
+  console.error(`Usage: import-translations <directory/file>`)
+  process.exit(2)
+}
+
+let target
+try {
+  target = realpathSync(targetRelative)
+} catch (e) {
+  console.error(`Bad path: ${targetRelative}`)
+  process.exit(3)
+}
+
 async function run() {
   const translations = await getTranslations()
   const allWarnings = []
 
-  for (const file of getJavascriptFiles(`.`)) {
+  for (const file of getJavascriptFiles(target)) {
     const translationsFile = file.replace(/\.js$/, `.translations.js`)
     const translationsFileRelative = translationsFile.slice(
       translationsFile.lastIndexOf(`/`) + 1

--- a/translationsImporter.js
+++ b/translationsImporter.js
@@ -1,5 +1,11 @@
 import https from "https"
-import { writeFileSync, readdirSync, lstatSync, readFileSync } from "fs"
+import {
+  writeFileSync,
+  readdirSync,
+  lstatSync,
+  readFileSync,
+  statSync,
+} from "fs"
 import pathTools from "path"
 
 export async function getTranslations() {
@@ -47,14 +53,20 @@ export async function getTranslations() {
   return translations
 }
 
-export function* getJavascriptFiles(dir) {
-  for (const file of readdirSync(dir)) {
-    const path = pathTools.join(dir, file)
-    const stat = lstatSync(path)
-    if (stat.isDirectory()) {
-      yield* getJavascriptFiles(path) //recurse
-    } else if (path.endsWith(`.js`)) {
-      yield path
+export function* getJavascriptFiles(dirOrFile) {
+  if (statSync(dirOrFile).isFile()) {
+    const file = dirOrFile
+    yield file
+  } else {
+    const dir = dirOrFile
+    for (const file of readdirSync(dir)) {
+      const path = pathTools.join(dir, file)
+      const stat = lstatSync(path)
+      if (stat.isDirectory()) {
+        yield* getJavascriptFiles(path) //recurse
+      } else if (path.endsWith(`.js`)) {
+        yield path
+      }
     }
   }
 }


### PR DESCRIPTION
This changes so that you have to provide an argument to what file or
directory you would like to import translations. Helps in avoiding
importing unrelated translations (which cause unnecessary conflicts +
extra QA headache)