### PR TITLE
Prefer to place translations file in assigned subfolder if it exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@
 import { writeFileSync, readFileSync, unlinkSync, realpathSync } from "fs"
 import { exec } from "child_process"
 
-import { getTranslations, getJavascriptFiles } from "./translationsImporter.js"
+import {
+  getTranslations,
+  getJavascriptFiles,
+  getTranslationsFile,
+} from "./translationsImporter.js"
 import inject from "./translationsInjecter.js"
 
 if (!process.env.TRANSLATIONS_URL) {
@@ -32,9 +36,9 @@ async function run() {
   const allWarnings = []
 
   for (const file of getJavascriptFiles(target)) {
-    const translationsFile = file.replace(/\.js$/, `.translations.js`)
+    const translationsFile = await getTranslationsFile(file)
     const translationsFileRelative = translationsFile.slice(
-      translationsFile.lastIndexOf(`/`) + 1
+      file.lastIndexOf(`/`) + 1
     )
 
     const contents = readFileSync(file, `utf-8`)

--- a/translationsImporter.js
+++ b/translationsImporter.js
@@ -74,3 +74,24 @@ export function* getJavascriptFiles(dirOrFile) {
     }
   }
 }
+
+export async function getTranslationsFile(forFile) {
+  const location1 = forFile.replace(/\.js$/, `.translations.js`)
+
+  const directory2 = forFile.replace(/\.js$/, ``)
+  const location2 = forFile.replace(/\.js$/, `/translations.js`)
+
+  if (dirExists(directory2)) {
+    return location2
+  } else {
+    return location1
+  }
+}
+
+function dirExists(path) {
+  try {
+    return statSync(path).isDirectory()
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
Let's say we have a `file.js` that we want translations for.

if this file has a sibling directory with the same name `file/`, then the translations file used will be `file/translations.js`.

If not, then previous behavior is used (translations file will be `file.translations.js`)