### PR TITLE
Read open office file instead of tsv for multiline support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "es2020": true,
+    "browser": false
+  },
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true
+    }
+  },
+  "rules": {
+    "quotes": ["error", "backtick"],
+    "eqeqeq": "error",
+    "no-var": ["error"],
+    "no-console": ["warn", {
+      "allow": ["warn", "error", "debug"]
+    }]
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": false,
+  "singleQuote": false
+}

--- a/index.js
+++ b/index.js
@@ -32,7 +32,14 @@ try {
 }
 
 async function run() {
-  const translations = await getTranslations()
+  let translations
+  try {
+    translations = await getTranslations()
+  } catch (e) {
+    console.error(`Failed to load translations.`, e)
+    return
+  }
+
   const allWarnings = []
 
   for (const file of getJavascriptFiles(target)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,125 @@
 {
   "name": "import-translations",
   "version": "1.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "node-stream-zip": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.12.0.tgz",
+      "integrity": "sha512-HZ3XehqShTFj9gHauRJ3Bri9eiCTOII7/crtXzURtT14NdnOFs9Ia5E82W7z3izVBNx760tqwddxrBJVG52Y1Q=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "requires": {
+        "rimraf": "^3.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,10 @@
   },
   "author": "Mika",
   "type": "module",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "node-stream-zip": "^1.12.0",
+    "tmp": "^0.2.1",
+    "xml2js": "^0.4.23"
+  }
 }

--- a/translationsImporter.js
+++ b/translationsImporter.js
@@ -7,54 +7,217 @@ import {
   statSync,
 } from "fs"
 import pathTools from "path"
+import tmp from "tmp"
+import StreamZip from "node-stream-zip"
+import xml2js from "xml2js"
 
-export async function getTranslations() {
-  const translations = {}
+const fetchDocument = (url) =>
+  new Promise((fetchRes) => {
+    https.get(url, (res) => {
+      res.setEncoding(`binary`)
+      let data = ``
+      res.on(`data`, (chunk) => {
+        data += chunk
+      })
+      res.on(`end`, () => {
+        if (`${res.statusCode}`[0] === `3`) {
+          fetchDocument(res.headers.location).then(fetchRes)
+        } else {
+          fetchRes(data)
+        }
+      })
+    })
+  })
 
-  const fetch = (url = process.env.TRANSLATIONS_URL) =>
-    new Promise((fetchRes) => {
-      https.get(url, (res) => {
-        res.setEncoding("utf8")
-        let data = ""
-        res.on("data", (chunk) => {
-          data += chunk
-        })
-        res.on("end", () => {
-          if (`${res.statusCode}`[0] === `3`) {
-            fetch(res.headers.location).then(fetchRes)
-          } else {
-            fetchRes(data)
-          }
-        })
+const extractContentXmlFromZip = (zipPath, tempPath) =>
+  new Promise((resolve, reject) => {
+    const zip = new StreamZip({ file: zipPath })
+
+    zip.on(`ready`, () => {
+      const xmlPath = pathTools.join(tempPath, `extracted.xml`)
+      zip.extract(`content.xml`, xmlPath, (err) => {
+        if (err) {
+          console.error(`Failed to find open office content in zip file`)
+          reject()
+        } else {
+          zip.close()
+          resolve(xmlPath)
+        }
       })
     })
 
-  const [columns, ...lines] = (await fetch())
-    .split("\r\n")
-    .map((line) => line.trim().split("\t"))
-    .filter((line) => line.length > 1)
+    zip.on(`error`, (e) => {
+      console.error(
+        `Failed to unpack zip file, is your env variable pointing to the ods export?`
+      )
+      reject(null)
+    })
+  })
+
+const getCellTextValue = (input) => {
+  // Different ways a cell could look
+  // {
+  //   "$": {
+  //     "table:style-name": "ce1",
+  //     "office:value-type": "string",
+  //     "calcext:value-type": "string"
+  //   },
+  //   "text:p": [
+  //     "line 1"
+  //   ]
+  // }
+  // {
+  //   "$": {
+  //     "table:style-name": "ce50",
+  //     "office:value-type": "string",
+  //     "calcext:value-type": "string"
+  //   },
+  //   "text:p": [
+  //     {
+  //       "text:a": [
+  //         {
+  //           "_": "line 1",
+  //           "$": {
+  //             "xlink:href": "https://lingio.github.io/web-ui/#x-page-portal-current",
+  //             "xlink:type": "simple"
+  //           }
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // }
+  // {
+  //   "$": {
+  //     "table:style-name": "ce52",
+  //     "office:value-type": "string",
+  //     "calcext:value-type": "string"
+  //   },
+  //   "text:p": [
+  //     "line 1",
+  //     "line 2",
+  //     "line 3"
+  //     ...
+  //   ]
+  // }
+
+  if (!input) {
+    return ``
+  }
+
+  input = input[`text:p`]
+
+  if (!input) {
+    return ``
+  }
+
+  input = input
+    .map((line) => {
+      if (typeof line === `string`) {
+        return line
+      }
+
+      if (line[`text:a`]) {
+        return line[`text:a`][0][`_`]
+      }
+
+      return ``
+    })
+    .join(`\n`)
+
+  return input
+}
+
+const getCellRepeatCount = (input) => {
+  // And a cell could contain a repeat command
+  // {
+  //   "$": {
+  //     "table:number-columns-repeated": "1006"
+  //   }
+  // }
+
+  if (!input) {
+    return 1
+  }
+
+  input = input[`$`]
+
+  if (!input) {
+    return 1
+  }
+
+  input = input[`table:number-columns-repeated`]
+
+  if (!input) {
+    return 1
+  }
+
+  return ~~input
+}
+
+const parseCell = (input) => {
+  const text = getCellTextValue(input)
+  const repeat = getCellRepeatCount(input)
+  const out = []
+  for (let i = 0; i < repeat; i++) {
+    out.push(text)
+  }
+  return out
+}
+
+const cleanDoc = (input) => {
+  input = input[`office:document-content`]
+  input = input[`office:body`][0]
+  input = input[`office:spreadsheet`][0]
+  input = input[`table:table`][0]
+  input = input[`table:table-row`]
+
+  const [columns, ...lines] = input.map((row) => {
+    return row[`table:table-cell`].map(parseCell).flat()
+  })
+
+  const translations = {}
 
   lines.forEach(([id, _batch, _context, _examples, ...dynamicValues]) => {
-    const scopes = _context.split(" ")[0].split("/")
-    if (id.length < 1 || id[0] === "#") {
+    const scopes = _context.split(` `)[0].split(`/`)
+    if (id.length < 1 || id[0] === `#`) {
       return
     }
 
     dynamicValues.forEach((v, i) => {
       const k = columns[i + 4]
 
-      if (v.length < 1 || v[0] === "#" || v === "...") {
+      if (v.length < 1 || v === `...`) {
         return
       }
 
       if (translations[k] === undefined) {
         translations[k] = {}
       }
+
       translations[k][id] = v
     })
   })
 
   return translations
+}
+
+export async function getTranslations() {
+  const url = process.env.TRANSLATIONS_URL
+
+  const tempPath = tmp.dirSync().name
+  const odsFile = pathTools.join(tempPath, `source.ods`)
+
+  const odsData = await fetchDocument(url)
+  writeFileSync(odsFile, odsData, `binary`)
+
+  const xmlPath = await extractContentXmlFromZip(odsFile, tempPath)
+  const xmlData = readFileSync(xmlPath, `utf-8`)
+
+  const xmlParser = new xml2js.Parser()
+  const parsedXml = await xmlParser.parseStringPromise(xmlData)
+  const cleanXml = cleanDoc(parsedXml)
+
+  return cleanXml
 }
 
 export function* getJavascriptFiles(dirOrFile) {

--- a/translationsImporter.js
+++ b/translationsImporter.js
@@ -120,6 +120,10 @@ const getCellTextValue = (input) => {
         return line[`text:a`][0][`_`]
       }
 
+      if (line[`_`]) {
+        return line[`_`]
+      }
+
       return ``
     })
     .join(`\n`)


### PR DESCRIPTION
This change reads ODS (open office) files from google instead of tsv/csv, which of none seems to support linebreaks, this one will support having markdown in the translation document.

You need to update your env variables to point to this instead:
`TRANSLATIONS_URL="https://docs.google.com/spreadsheets/d/1cL9kxvUgs9Bst2ZiAE3UDly6Azp03iokgtyfXP9fhjk/pub?gid=1904984372&single=true&output=ods"`

Adds node dependencies :/
